### PR TITLE
Feat/firebase register improvements

### DIFF
--- a/src/main/java/com/notesvault/config/AppConfig.java
+++ b/src/main/java/com/notesvault/config/AppConfig.java
@@ -1,5 +1,6 @@
 package com.notesvault.config;
 
+import com.google.firebase.auth.FirebaseAuth;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -28,5 +29,14 @@ public class AppConfig {
     @Bean
     public org.slf4j.Logger appLogger() {
         return org.slf4j.LoggerFactory.getLogger("NotesVault");
+    }
+
+    /**
+     * Bean for  FirebaseAuth
+     * @return Instance of FirebaseAuth
+     */
+    @Bean
+    public com.google.firebase.auth.FirebaseAuth firebaseAuth() {
+        return com.google.firebase.auth.FirebaseAuth.getInstance();
     }
 } 

--- a/src/main/java/com/notesvault/controller/auth/RegisterController.java
+++ b/src/main/java/com/notesvault/controller/auth/RegisterController.java
@@ -67,7 +67,7 @@ public class RegisterController {
         logger.info("Solicitud de reenvío de correo de confirmación para usuario: {}", email);
         try {
             // Verificar si el usuario existe
-            if (!registerService.existsUserByEmail(email)) {
+            if (!registerService.userExists(email)) {
                 logger.warn("Intento de reenvío para usuario inexistente: {}", email);
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Usuario no encontrado");
             }

--- a/src/main/java/com/notesvault/model/authlogic/RegisterService.java
+++ b/src/main/java/com/notesvault/model/authlogic/RegisterService.java
@@ -1,22 +1,18 @@
 package com.notesvault.model.authlogic;
 
-import com.google.cloud.firestore.FieldValue;
+import com.google.cloud.firestore.Firestore;
+import com.google.firebase.auth.AuthErrorCode;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.UserRecord;
 import com.notesvault.dtos.RegisterRequest;
 import com.notesvault.model.entities.User;
 import org.apache.commons.validator.routines.EmailValidator;
-import org.passay.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.WriteResult;
-import com.google.api.core.ApiFuture;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 @Service // Marca la clase como un servicio
 public class RegisterService {
@@ -25,11 +21,13 @@ public class RegisterService {
     private final Firestore firestore;
     private final ConfirmationEmailService confirmationEmailService;
     private final TokenService tokenService;
+    private final FirebaseAuth firebaseAuth;
 
-    public RegisterService(Firestore firestore, ConfirmationEmailService confirmationEmailService, TokenService tokenService) {
+    public RegisterService(Firestore firestore, ConfirmationEmailService confirmationEmailService, TokenService tokenService, FirebaseAuth firebaseAuth) {
         this.firestore = firestore;
         this.confirmationEmailService = confirmationEmailService;
         this.tokenService = tokenService;
+        this.firebaseAuth = firebaseAuth;
     }
 
     public void registerUser(RegisterRequest request)  {
@@ -37,92 +35,76 @@ public class RegisterService {
         String email = request.getEmail();
         String password = request.getPassword();
 
-        if (existsUserByEmail(email)) {
-            logger.warn("Intento de registro con email ya existente: {}", email);
-            throw new ResponseStatusException(HttpStatus.CONFLICT,"Este email ya se encuentra registrado");
-        }
         if (!validateEmail(email)) {
             logger.warn("Intento de registro con correo inválido: {}", email);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"Correo electrónico invalido");
         }
 
-        if (!validatePassword(password)) {
-            logger.warn("Intento de registro con contraseña no válida para usuario: {}", email);
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"Contraseña inválida (8-30 caracteres, sin espacios, una mayúscula, un dígito y un símbolo)");
+        try{
+            //Create the request for a new user of Firebase
+            UserRecord.CreateRequest createRequest = new UserRecord.CreateRequest().
+                    setEmail(email).setPassword(password).setDisplayName(request.getUserName()).
+                    setEmailVerified(false); //The user needs to verify his email
+
+            //Calling of firebase to create the user (sdk firebase object)
+            UserRecord userRecord = firebaseAuth.createUser(createRequest);
+            String uid = userRecord.getUid();
+            logger.info("Usuario creado exitosamente en Firebase Auth con UID: {}",uid);
+
+            //Saving aditional information of the user in firestore
+            User userProfile = new User(uid, email, request.getUserName());
+            firestore.collection("users").document(uid).set(userProfile);
+            logger.info("Perfil de usuario guardado en Firestore para UID: {}", uid);
+
+            //Send confirmation email
+            TokenService.GeneratedTokenInfo tokenInfo = tokenService.generateSecureToken(email, "confirmation");
+            confirmationEmailService.sendConfirmationEmailAsync(email, tokenInfo.getRawToken(), request.getUserName())
+                    .exceptionally(throwable -> {
+                        logger.error("Error al enviar correo de confirmación a {}: {}", email, throwable.getMessage());
+                        return null;
+                    });
+
+            logger.info("Proceso de registro para {} completado.", email);
+
+        } catch (FirebaseAuthException e) {
+            // Handle Firebase Specific Errors
+            logger.error("Error de Firebase al registrar a {}: {}", email, e.getAuthErrorCode(), e);
+            String publicMessage;
+            HttpStatus status;
+
+            //Get error code
+            String errorCode = e.getAuthErrorCode().name();
+
+            if (errorCode.equals("EMAIL_ALREADY_EXISTS")) {
+                publicMessage = "Este email ya se encuentra registrado.";
+                status = HttpStatus.CONFLICT;
+
+            } else if (errorCode.equals("WEAK_PASSWORD")) {
+                publicMessage = "La contraseña es demasiado débil. Debe tener al menos 6 caracteres.";
+                status = HttpStatus.BAD_REQUEST;
+            } else {
+                publicMessage = "Error interno al registrar el usuario.";
+                status = HttpStatus.INTERNAL_SERVER_ERROR;
+            }
+            throw new ResponseStatusException(status, publicMessage);
         }
-        
-        //Se hashea la contraseña despues de hacer la validación
-        User user = new User(request.getEmail(), request.getUserName(), password);
-        boolean success = saveUserToFirestore(user);
-        if (!success) {
-            logger.error("Fallo al guardar usuario en Firestore: {}", user.getEmail());
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,"Error al guardar el usuario en Firestore");
+    }
+
+    public boolean userExists(String email) {
+        try {
+            // This method return an exception if the email doesnt exist
+            firebaseAuth.getUserByEmail(email);
+            return true;
+        } catch (FirebaseAuthException e) {
+            if (e.getAuthErrorCode() == AuthErrorCode.USER_NOT_FOUND || e.getAuthErrorCode() == AuthErrorCode.EMAIL_NOT_FOUND) {
+                return false;
+            }
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error al verificar el usuario.", e);
         }
-        
-        // Generar token de confirmación
-        TokenService.GeneratedTokenInfo tokenInfo = tokenService.generateSecureToken(user.getEmail(), "confirmation");
-        logger.info("Token de confirmación generado para usuario: {}", user.getEmail());
-        
-        // Enviar correo de confirmación de forma asíncrona (no bloquea la respuesta)
-        confirmationEmailService.sendConfirmationEmailAsync(user.getEmail(), tokenInfo.getRawToken(), user.getUserName())
-            .exceptionally(throwable -> {
-                logger.error("Error al enviar correo de confirmación a {}: {}", user.getEmail(), throwable.getMessage());
-                return null;
-            });
-            
-        logger.info("Usuario {} registrado exitosamente en Firestore", user.getEmail());
     }
 
     private boolean validateEmail(String email) {
         return EmailValidator.getInstance().isValid(email);
     }
 
-    public boolean validatePassword(String password) {
-        PasswordValidator validator = new PasswordValidator(Arrays.asList(
-                new LengthRule(8, 30),
-                new CharacterRule(EnglishCharacterData.UpperCase, 1),
-                new CharacterRule(EnglishCharacterData.LowerCase, 1),
-                new CharacterRule(EnglishCharacterData.Digit, 1),
-                new CharacterRule(EnglishCharacterData.Special, 1),
-                new WhitespaceRule()
-        ));
-        return validator.validate(new PasswordData(password)).isValid();
-    }
-
-    public boolean existsUserByEmail(String email) {
-        try {
-            ApiFuture<com.google.cloud.firestore.DocumentSnapshot> future = firestore.collection("users").document(email).get();
-            boolean exists = future.get().exists();
-            logger.debug("Verificación de email en Firestore: {} - Existe: {}", email, exists);
-            return exists;
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("Error al verificar el email en Firestore: {}", e.getMessage(), e);
-            Thread.currentThread().interrupt();
-            return false;
-        }
-    }
-
-    public boolean saveUserToFirestore(User user) {
-
-        Map<String, Object> userMap = new HashMap<>();
-        userMap.put("email", user.getEmail());
-        userMap.put("userName", user.getUserName());
-        userMap.put("password", user.getPassword());
-        userMap.put("isActive", true);
-        userMap.put("isConfirmed", false);
-        userMap.put("createdAt", FieldValue.serverTimestamp()); //Se anexa fecha de creacion
-
-
-        ApiFuture<WriteResult> future = firestore.collection("users").document(user.getEmail()).set(userMap);
-
-        try {
-            WriteResult result = future.get();
-            logger.info("Usuario guardado exitosamente en Firestore en: {}", result.getUpdateTime());
-            return true;
-        } catch (InterruptedException | ExecutionException e) {
-            logger.error("Error al guardar el usuario en Firestore: {}", e.getMessage(), e);
-            Thread.currentThread().interrupt();
-            return false;
-        }
-    }
 }

--- a/src/main/java/com/notesvault/model/authlogic/RegisterService.java
+++ b/src/main/java/com/notesvault/model/authlogic/RegisterService.java
@@ -66,7 +66,13 @@ public class RegisterService {
 
             logger.info("Proceso de registro para {} completado.", email);
 
-        } catch (FirebaseAuthException e) {
+        } catch (IllegalArgumentException e) {
+            // If the password is invalid before calling firestore
+            logger.error("Error de validación del SDK de Firebase: {}", e.getMessage());
+            String publicMessage = "La contraseña es inválida. Debe tener al menos 6 caracteres.";
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, publicMessage);
+
+        }catch (FirebaseAuthException e) {
             // Handle Firebase Specific Errors
             logger.error("Error de Firebase al registrar a {}: {}", email, e.getAuthErrorCode(), e);
             String publicMessage;

--- a/src/main/java/com/notesvault/model/entities/User.java
+++ b/src/main/java/com/notesvault/model/entities/User.java
@@ -1,9 +1,6 @@
 package com.notesvault.model.entities;
 
 import com.google.cloud.firestore.annotation.ServerTimestamp;
-import org.mindrot.jbcrypt.BCrypt;
-
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 

--- a/src/main/java/com/notesvault/model/entities/User.java
+++ b/src/main/java/com/notesvault/model/entities/User.java
@@ -1,42 +1,91 @@
 package com.notesvault.model.entities;
 
+import com.google.cloud.firestore.annotation.ServerTimestamp;
 import org.mindrot.jbcrypt.BCrypt;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 public class User {
 
+    private String uid;
     private String email;
     private String userName;
-    private String password;
+    private boolean isActive;
+    private boolean isConfirmed;
+
+    @ServerTimestamp // Firestore fill this variable, automatically
+    private Date createdAt;
+
 
     private List<Note> notesList;
-    public User(){
-
+    public User() {
+        // Firestore needs an empty constructor to convert the document into a java object
     }
-    public User(String email,String userName, String password) {
+
+    public User(String uid, String email, String userName, boolean isActive, boolean isConfirmed, List<Note> notesList) {
+        this.uid = uid;
         this.email = email;
         this.userName = userName;
-        this.password = hashPassword(password);
-        notesList = new ArrayList<>();
+        this.isActive = true; //Default value during registration
+        this.isConfirmed = false;
+        this.notesList = notesList;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
     }
 
     public String getUserName() {
         return userName;
     }
 
-    public String getPassword() {
-        return password;
-    }
-    public String getEmail() {
-        return email;
-    }
-    private String hashPassword(String password) {
-        return BCrypt.hashpw(password, BCrypt.gensalt());
+    public void setUserName(String userName) {
+        this.userName = userName;
     }
 
-    public void setPassword(String password) {
-        this.password =  hashPassword(password);
+    public boolean isActive() {
+        return isActive;
+    }
+
+    public void setActive(boolean active) {
+        isActive = active;
+    }
+
+    public boolean isConfirmed() {
+        return isConfirmed;
+    }
+
+    public void setConfirmed(boolean confirmed) {
+        isConfirmed = confirmed;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public List<Note> getNotesList() {
+        return notesList;
+    }
+
+    public void setNotesList(List<Note> notesList) {
+        this.notesList = notesList;
     }
 }

--- a/src/main/java/com/notesvault/model/entities/User.java
+++ b/src/main/java/com/notesvault/model/entities/User.java
@@ -1,6 +1,8 @@
 package com.notesvault.model.entities;
 
 import com.google.cloud.firestore.annotation.ServerTimestamp;
+
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -21,13 +23,13 @@ public class User {
         // Firestore needs an empty constructor to convert the document into a java object
     }
 
-    public User(String uid, String email, String userName, boolean isActive, boolean isConfirmed, List<Note> notesList) {
+    public User(String uid, String email, String userName) {
         this.uid = uid;
         this.email = email;
         this.userName = userName;
-        this.isActive = true; //Default value during registration
+        this.isActive = true;    
         this.isConfirmed = false;
-        this.notesList = notesList;
+        this.notesList = new ArrayList<>();
     }
 
     public String getUid() {


### PR DESCRIPTION
**Brief Description**

The user registration service is completely refactored to delegate authentication logic to Firebase Authentication instead of manually handling passwords.

This change significantly improves security by no longer storing or managing hashed passwords directly within the application. In addition, it centralizes user creation logic in a dedicated and robust service such as Firebase Auth.


 **Changes:**

- The RegisterService now uses FirebaseAuth.createUser() to create new users.

- The User entity no longer stores the password. Instead, it now saves the Firebase uid to link the Firestore profile with the authentication user. So now, we use uid instead of email. Because email can change with the time, but uid not.

- A new userExists(email) method has been added, which uses FirebaseAuth.getUserByEmail() to check if a user already exists.

- The /auth/resend-confirmation endpoint has been updated to use the new userExists method.

- Error handling is now managed using the official error codes provided by Firebase.